### PR TITLE
Potential bug fix for choosing repos for PMC

### DIFF
--- a/site/js/projects.js
+++ b/site/js/projects.js
@@ -619,7 +619,7 @@ function renderCommitteePage(committeeId) {
 
     var repos = [];
     for (var r in repositories) {
-        if (r.startsWith(committeeId)) {
+        if (r.startsWith(committeeId + "-")) {
             repos.push(r);
         }
     }


### PR DESCRIPTION
Hmm, perhaps this is wrong location since source is in svn? But since we have a PMC `lucene` and another `lucenenet`, there are several bugs around the scripts that assume that one PMC name is not a prefix of another, this is one. 

Related to https://issues.apache.org/jira/browse/COMDEV-425