### PR TITLE
Update Cordova DOAP location

### DIFF
--- a/data/projects.xml
+++ b/data/projects.xml
@@ -158,7 +158,7 @@
   <location>http://svn.apache.org/repos/asf/commons/cms-site/trunk/doap/doap_validator.rdf</location>
   <location>http://svn.apache.org/repos/asf/commons/cms-site/trunk/doap/doap_vfs.rdf</location>
   <location>http://svn.apache.org/repos/asf/commons/cms-site/trunk/doap/doap_weaver.rdf</location>
-  <location>http://svn.apache.org/repos/asf/cordova/site/public/infra/doap_Cordova.rdf</location>
+  <location>https://cordova.apache.org/infra/doap_Cordova.rdf</location>
   <location>http://couchdb.apache.org/couchdb-doap.rdf</location>
   <location>http://svn.apache.org/repos/asf/creadur/rat/doap_RAT.rdf</location>
   <location>http://svn.apache.org/repos/asf/creadur/tentacles/doap_tentacles.rdf</location>


### PR DESCRIPTION
The git source for the DOAP file lives here: https://github.com/apache/cordova-docs/tree/master/www/infra

It is included and deployed to the cordova.apache.org website as part of the cordova-docs repo build process.