### PR TITLE
Annotator is a podling and should not be included

### DIFF
--- a/data/projects.xml
+++ b/data/projects.xml
@@ -36,7 +36,6 @@
   <location>https://raw.githubusercontent.com/apache/airflow/main/doap_airflow.rdf</location>
   <location>https://svn.apache.org/repos/asf/allura/doap_Allura.rdf</location>
   <location>http://ambari.apache.org/doap.rdf</location>
-  <location>https://annotator.apache.org/doap.rdf</location>
   <location>https://ant.apache.org/doap_Ant.rdf</location>
   <location>https://ant.apache.org/antlibs/antunit/doap_AntUnit.rdf</location>
   <location>https://ant.apache.org/antlibs/compress/doap_CompressAntlib.rdf</location>


### PR DESCRIPTION
In the Apache Trusted Release we are taking project information from https://projects.apache.org/json/foundation/projects.json

Unfortunately this currently includes `incubator-annotator`. I believe that removing the annotator soap file will remove this unexpected entry.