### PR TITLE
Add Apache Magpie DOAP

### DIFF
--- a/data/projects.xml
+++ b/data/projects.xml
@@ -260,6 +260,7 @@
   <location>http://lucenenet.apache.org/doap_Lucene_Net.rdf</location>
   <location>http://lucy.apache.org/doap.rdf</location>
   <location>http://linkis.apache.org/doap.rdf</location>
+  <location>https://raw.githubusercontent.com/apache/magpie/main/doap_Magpie.rdf</location>
   <location>http://svn.apache.org/repos/asf/mahout/trunk/doap_Mahout.rdf</location>
   <location>https://manifoldcf.apache.org/doap_ManifoldCF.rdf</location>
   <!-- retired: location>http://marmotta.apache.org/doap.rdf</location -->


### PR DESCRIPTION
Adds the DOAP file for Apache Magpie to the projects feed.

DOAP: https://raw.githubusercontent.com/apache/magpie/main/doap_Magpie.rdf

🤖 Generated with [Claude Code](https://claude.com/claude-code)